### PR TITLE
added metadata argument to create_post method.

### DIFF
--- a/mattermost/__init__.py
+++ b/mattermost/__init__.py
@@ -1072,7 +1072,7 @@ class MMApi:
 #+ **POSTS**
 
 
-    def create_post(self, channel_id, message, props=None, filepaths=None, root_id=None, **kwargs):
+    def create_post(self, channel_id, message, props=None, filepaths=None, root_id=None, metadata=None, **kwargs):
         """
         Create a new post in a channel. To create the post as a comment on another post, provide root_id.
 
@@ -1082,6 +1082,7 @@ class MMApi:
             props (string, optional): see MM-API docs.
             filepaths (list, optional): Paths to upload files from and attach to post.
             root_id (string, optional): see MM-API docs.
+            metadata (dict, optional): Priority metadata. see MM-API docs.
 
         Returns:
             dict: created Post.
@@ -1098,10 +1099,10 @@ class MMApi:
             "channel_id": channel_id,
             "message": message,
             **({"props": props} if props else {"props": {"from_webhook":"true"}}),
+            **({"metadata": metadata} if metadata else {"metadata": {}}),
             "root_id":root_id,
             "file_ids": file_ids,
         }, **kwargs)
-
 
 
     def create_ephemeral_post(self, channel_id, message, user_id, **kwargs):


### PR DESCRIPTION
Added metadata argument to be able to set priority and requested_ack for ew post. https://api.mattermost.com/#tag/posts/operation/CreatePost
Like this:
<img width="323" alt="image" src="https://github.com/someone-somenet-org/mattermost-python-api/assets/3694278/dc8f81ac-ccbf-43c0-95b0-11510dfeadc8">
