### PR TITLE
Add optional parameters 'after' and 'before' to get_posts_for_channel

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,7 +220,7 @@ Ordered by https://api.mattermost.com/
   + **``get_post (post_id, **kwargs)``**
   + **``delete_post (post_id, **kwargs)``**
   + **``patch_post (post_id, message=None, is_pinned=None, props=None, **kwargs)``**
-  + **``get_posts_for_channel (channel_id, **kwargs)``**
+  + **``get_posts_for_channel (channel_id, after=None, before=None, **kwargs)``**
 + **FILES**
   + **``upload_file (channel_id, filepath, **kwargs)``**
   + **``get_file (file_id, **kwargs)``**

--- a/mattermost/__init__.py
+++ b/mattermost/__init__.py
@@ -1219,12 +1219,14 @@ class MMApi:
 
 
 
-    def get_posts_for_channel(self, channel_id, **kwargs):
+    def get_posts_for_channel(self, channel_id, after=None, before=None, **kwargs):
         """
         Generator: Get a page of posts in a channel. Use the query parameters to modify the behaviour of this endpoint.
 
         Args:
             channel_id (string): The channel ID to iterate over.
+            after (string, optional): A post id to select the posts that came after this one
+            before (string, optional): A post id to select the posts that came before this one
 
         Returns:
             generates: Post.
@@ -1234,7 +1236,7 @@ class MMApi:
         """
         page = 0
         while True:
-            data_page = self._get("/v4/channels/"+channel_id+"/posts", params={"page":str(page)}, **kwargs)
+            data_page = self._get("/v4/channels/"+channel_id+"/posts", params={"page":str(page), "after":after, "before":before}, **kwargs)
 
             if data_page["order"] == []:
                 break


### PR DESCRIPTION
The Mattermost API [get posts for a channel](https://developers.mattermost.com/api-documentation/#/operations/GetPostsForChannel) provides the optional parameters `after` and `before` to receive only posts that came after or before a given post.

This pull request extends the function `get_posts_for_channel` by respective optional parameters.